### PR TITLE
[Car Racing] Submit SungKyum Kim's mission

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,6 @@
     * [x] The round number input should be larger than zero.
     * [x] The Round number input is not possible, not numbers.
 * [x] Car names must be entered as a comma-separated list.
-* [ ] When printing the progress of each car, the car's name must be displayed alongside its movement.
-* [ ] After the race is complete, the winners must be displayed.
-* [ ] If there are multiple winners, their names must be separated by commas.
+* [x] When printing the progress of each car, the car's name must be displayed alongside its movement.
+* [x] After the race is complete, the winners must be displayed.
+* [x] If there are multiple winners, their names must be separated by commas.

--- a/README.md
+++ b/README.md
@@ -4,32 +4,36 @@
 
 ### Domain Features
 
-* [x] Each car must have a name, and names must not exceed 5 characters.
-* [x] Car names must not be empty.
-* [x] Car names must be unique.
-* [x] A car can move only when the power condition is satisfied.
-    * [x] The power is a random number between 0 and 9.
-    * [x] The car moves forward if the power is 4 or greater.
-* [x] The game must proceed for a given number of rounds.
-    * [x] In each round, every car attempts to move once.
-    * [x] The result of each round (car positions) must be recorded.
-* [x] After all rounds, determine the winner(s).
-    * [x] The winner is the car(s) that has moved the farthest.
-    * [x] If there are multiple cars with the same farthest position, all are winners.
+| Feature                                                                                                | Status |
+|--------------------------------------------------------------------------------------------------------|--------|
+| Each car must have a name, and names must not exceed 5 characters.                                     | ✅      |
+| Car names must not be empty.                                                                           | ✅      |
+| Car names must be unique.                                                                              | ✅      |
+| A car can move only when the power condition is satisfied.                                             | ✅      |
+| &nbsp;&nbsp;&nbsp;&nbsp;– The power is a random number between 0 and 9.                                | ✅      |
+| &nbsp;&nbsp;&nbsp;&nbsp;– The car moves forward if the power is 4 or greater.                          | ✅      |
+| The game must proceed for a given number of rounds.                                                    | ✅      |
+| &nbsp;&nbsp;&nbsp;&nbsp;– In each round, every car attempts to move once.                              | ✅      |
+| &nbsp;&nbsp;&nbsp;&nbsp;– The result of each round (car positions) must be recorded.                   | ✅      |
+| After all rounds, determine the winner(s).                                                             | ✅      |
+| &nbsp;&nbsp;&nbsp;&nbsp;– The winner is the car(s) that has moved the farthest.                        | ✅      |
+| &nbsp;&nbsp;&nbsp;&nbsp;– If there are multiple cars with the same farthest position, all are winners. | ✅      |
+
+---
 
 ### Input/Output Features
 
-* [x] If the user inputs invalid data, the program must throw an `IllegalArgumentException`.
-    * [x] Input data cannot be empty.
-    * [x] Only one number of rounds can be entered.
-    * [x] The round number input should be larger than zero.
-    * [x] The Round number input is not possible, not numbers.
-* [x] Car names must be entered as a comma-separated list.
-* [x] When printing the progress of each car, the car's name must be displayed alongside its movement.
-* [x] After the race is complete, the winners must be displayed.
-* [x] If there are multiple winners, their names must be separated by commas.
-
----
+| Feature                                                                                          | Status |
+|--------------------------------------------------------------------------------------------------|--------|
+| If the user inputs invalid data, the program must throw an `IllegalArgumentException`.           | ✅      |
+| &nbsp;&nbsp;&nbsp;&nbsp;– Input data cannot be empty.                                            | ✅      |
+| &nbsp;&nbsp;&nbsp;&nbsp;– Only one number of rounds can be entered.                              | ✅      |
+| &nbsp;&nbsp;&nbsp;&nbsp;– The round number input should be larger than zero.                     | ✅      |
+| &nbsp;&nbsp;&nbsp;&nbsp;– The round number input must be numeric.                                | ✅      |
+| Car names must be entered as a comma-separated list.                                             | ✅      |
+| When printing the progress of each car, the car's name must be displayed alongside its movement. | ✅      |
+| After the race is complete, the winners must be displayed.                                       | ✅      |
+| If there are multiple winners, their names must be separated by commas.                          | ✅      |
 
 ### Commit Scopes Convention
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # kotlin-racingcar-precourse
+
+## Feature Specification
+
+### Domain Features
+
+* [ ] Each car must have a name, and names must not exceed 5 characters.
+* [ ] Car names must not be empty.
+* [ ] Car names must be unique.
+* [ ] A car must move forward if a random number (0~9) is 4 or greater.
+* [ ] Each car must attempt to move in every round.
+* [ ] The result of each round must be recorded.
+
+### Input/Output Features
+
+* [ ] If the user inputs invalid data, the program must throw an `IllegalArgumentException`.
+* [ ] Car names must be entered as a comma-separated list.
+* [ ] When printing the progress of each car, the car's name must be displayed alongside its movement.
+* [ ] After the race is complete, the winners must be displayed.
+* [ ] If there are multiple winners, their names must be separated by commas.

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@
 
 ### Input/Output Features
 
-* [ ] If the user inputs invalid data, the program must throw an `IllegalArgumentException`.
-    * [ ] Input data cannot be empty.
-* [ ] Car names must be entered as a comma-separated list.
+* [x] If the user inputs invalid data, the program must throw an `IllegalArgumentException`.
+    * [x] Input data cannot be empty.
+* [x] Car names must be entered as a comma-separated list.
 * [ ] When printing the progress of each car, the car's name must be displayed alongside its movement.
 * [ ] After the race is complete, the winners must be displayed.
 * [ ] If there are multiple winners, their names must be separated by commas.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 * [x] Each car must have a name, and names must not exceed 5 characters.
 * [x] Car names must not be empty.
 * [ ] Car names must be unique.
-* [ ] A car can move only when the power condition is satisfied.
+* [x] A car can move only when the power condition is satisfied.
     * [x] The power is a random number between 0 and 9.
-    * [ ] The car moves forward if the power is 4 or greater.
+    * [x] The car moves forward if the power is 4 or greater.
 * [ ] Each car must attempt to move in every round.
 * [ ] The result of each round must be recorded.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ### Domain Features
 
 * [ ] Each car must have a name, and names must not exceed 5 characters.
-* [ ] Car names must not be empty.
+* [x] Car names must not be empty.
 * [ ] Car names must be unique.
 * [ ] A car must move forward if a random number (0~9) is 4 or greater.
 * [ ] Each car must attempt to move in every round.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 * [x] Each car must have a name, and names must not exceed 5 characters.
 * [x] Car names must not be empty.
 * [ ] Car names must be unique.
-* [ ] A car must move forward if a random number (0~9) is 4 or greater.
+* [ ] A car can move only when the power condition is satisfied.
+    * [ ] The power is a random number between 0 and 9.
+    * [ ] The car moves forward if the power is 4 or greater.
 * [ ] Each car must attempt to move in every round.
 * [ ] The result of each round must be recorded.
 

--- a/README.md
+++ b/README.md
@@ -28,3 +28,27 @@
 * [x] When printing the progress of each car, the car's name must be displayed alongside its movement.
 * [x] After the race is complete, the winners must be displayed.
 * [x] If there are multiple winners, their names must be separated by commas.
+
+---
+
+### Commit Scopes Convention
+
+To make it easier to trace commits and match them with the feature specification, the following scope conventions are
+used in commit messages:
+
+| Scope    | Description                                                                                                |
+|----------|------------------------------------------------------------------------------------------------------------|
+| `domain` | Changes related to core business logic and domain rules (e.g. race rules, car behavior, round processing). |
+| `input`  | Parsing and validation of user inputs (e.g. car names, round count).                                       |
+| `output` | Printing the game progress and results (e.g. car positions, winners).                                      |
+| `readme` | Updates to documentation files such as `README.md` or spec clarifications.                                 |
+
+#### Example:
+
+```bash
+feat(domain): add race progression logic
+
+feat(input): add reading car names features
+
+docs(readme): add input constraints
+```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Domain Features
 
-* [ ] Each car must have a name, and names must not exceed 5 characters.
+* [x] Each car must have a name, and names must not exceed 5 characters.
 * [x] Car names must not be empty.
 * [ ] Car names must be unique.
 * [ ] A car must move forward if a random number (0~9) is 4 or greater.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,12 @@
 * [x] A car can move only when the power condition is satisfied.
     * [x] The power is a random number between 0 and 9.
     * [x] The car moves forward if the power is 4 or greater.
-* [ ] Each car must attempt to move in every round.
-* [ ] The result of each round must be recorded.
+* [ ] The game must proceed for a given number of rounds.
+    * [ ] In each round, every car attempts to move once.
+    * [ ] The result of each round (car positions) must be recorded.
+* [ ] After all rounds, determine the winner(s).
+    * [ ] The winner is the car(s) that has moved the farthest.
+    * [ ] If there are multiple cars with the same farthest position, all are winners.
 
 ### Input/Output Features
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     * [x] The power is a random number between 0 and 9.
     * [x] The car moves forward if the power is 4 or greater.
 * [ ] The game must proceed for a given number of rounds.
-    * [ ] In each round, every car attempts to move once.
+    * [x] In each round, every car attempts to move once.
     * [ ] The result of each round (car positions) must be recorded.
 * [ ] After all rounds, determine the winner(s).
     * [ ] The winner is the car(s) that has moved the farthest.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@
 
 * [x] If the user inputs invalid data, the program must throw an `IllegalArgumentException`.
     * [x] Input data cannot be empty.
+    * [ ] Only one number of rounds can be entered.
+    * [ ] The round number input should be larger than zero.
+    * [ ] The Round number input is not possible, not numbers.
 * [x] Car names must be entered as a comma-separated list.
 * [ ] When printing the progress of each car, the car's name must be displayed alongside its movement.
 * [ ] After the race is complete, the winners must be displayed.

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@
 * [x] A car can move only when the power condition is satisfied.
     * [x] The power is a random number between 0 and 9.
     * [x] The car moves forward if the power is 4 or greater.
-* [ ] The game must proceed for a given number of rounds.
+* [x] The game must proceed for a given number of rounds.
     * [x] In each round, every car attempts to move once.
-    * [ ] The result of each round (car positions) must be recorded.
-* [ ] After all rounds, determine the winner(s).
+    * [x] The result of each round (car positions) must be recorded.
+* [x] After all rounds, determine the winner(s).
     * [x] The winner is the car(s) that has moved the farthest.
     * [x] If there are multiple cars with the same farthest position, all are winners.
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@
 
 * [x] If the user inputs invalid data, the program must throw an `IllegalArgumentException`.
     * [x] Input data cannot be empty.
-    * [ ] Only one number of rounds can be entered.
-    * [ ] The round number input should be larger than zero.
-    * [ ] The Round number input is not possible, not numbers.
+    * [x] Only one number of rounds can be entered.
+    * [x] The round number input should be larger than zero.
+    * [x] The Round number input is not possible, not numbers.
 * [x] Car names must be entered as a comma-separated list.
 * [ ] When printing the progress of each car, the car's name must be displayed alongside its movement.
 * [ ] After the race is complete, the winners must be displayed.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
     * [x] In each round, every car attempts to move once.
     * [ ] The result of each round (car positions) must be recorded.
 * [ ] After all rounds, determine the winner(s).
-    * [ ] The winner is the car(s) that has moved the farthest.
-    * [ ] If there are multiple cars with the same farthest position, all are winners.
+    * [x] The winner is the car(s) that has moved the farthest.
+    * [x] If there are multiple cars with the same farthest position, all are winners.
 
 ### Input/Output Features
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 * [x] Each car must have a name, and names must not exceed 5 characters.
 * [x] Car names must not be empty.
-* [ ] Car names must be unique.
+* [x] Car names must be unique.
 * [x] A car can move only when the power condition is satisfied.
     * [x] The power is a random number between 0 and 9.
     * [x] The car moves forward if the power is 4 or greater.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 ### Input/Output Features
 
 * [ ] If the user inputs invalid data, the program must throw an `IllegalArgumentException`.
+    * [ ] Input data cannot be empty.
 * [ ] Car names must be entered as a comma-separated list.
 * [ ] When printing the progress of each car, the car's name must be displayed alongside its movement.
 * [ ] After the race is complete, the winners must be displayed.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 * [x] Car names must not be empty.
 * [ ] Car names must be unique.
 * [ ] A car can move only when the power condition is satisfied.
-    * [ ] The power is a random number between 0 and 9.
+    * [x] The power is a random number between 0 and 9.
     * [ ] The car moves forward if the power is 4 or greater.
 * [ ] Each car must attempt to move in every round.
 * [ ] The result of each round must be recorded.

--- a/src/main/kotlin/racingcar/Application.kt
+++ b/src/main/kotlin/racingcar/Application.kt
@@ -1,5 +1,25 @@
 package racingcar
 
+import racingcar.domain.*
+import racingcar.view.InputView
+import racingcar.view.OutputView
+
 fun main() {
-    // TODO: Implement the program
+    val inputView = InputView()
+    val carNames = inputView.readCarNames()
+    val cars = createCars(carNames)
+    val numberOfRounds = inputView.readNumberOfRounds()
+    val race = Race(Cars(cars), numberOfRounds)
+
+    val raceResults = race.start()
+
+    printResults(raceResults)
+}
+
+private fun createCars(carNames: List<String>) =
+    carNames.map { CarName(it) }.map { Car(it, RandomPowerGenerator()) }.toList()
+
+private fun printResults(raceResults: RaceResults) {
+    val outputView = OutputView()
+    outputView.printRaceResults(raceResults)
 }

--- a/src/main/kotlin/racingcar/Application.kt
+++ b/src/main/kotlin/racingcar/Application.kt
@@ -17,7 +17,7 @@ fun main() {
 }
 
 private fun createCars(carNames: List<String>) =
-    carNames.map { CarName(it) }.map { Car(it, RandomPowerGenerator()) }.toList()
+    carNames.map { CarName(it) }.map { Car(it, RandomPowerGenerator()) }
 
 private fun printResults(raceResults: RaceResults) {
     val outputView = OutputView()

--- a/src/main/kotlin/racingcar/domain/Car.kt
+++ b/src/main/kotlin/racingcar/domain/Car.kt
@@ -1,11 +1,11 @@
 package racingcar.domain
 
 class Car(val name: CarName, private val powerGenerator: PowerGenerator) {
-    var distance = 0
+    var position = 0
 
     fun move() {
         if (canMove()) {
-            distance++
+            position++
         }
     }
 

--- a/src/main/kotlin/racingcar/domain/Car.kt
+++ b/src/main/kotlin/racingcar/domain/Car.kt
@@ -1,11 +1,11 @@
 package racingcar.domain
 
 class Car(val name: CarName, private val powerGenerator: PowerGenerator) {
-    var position = 0
+    var position = Position(0)
 
     fun move() {
         if (canMove()) {
-            position++
+            position.increase()
         }
     }
 

--- a/src/main/kotlin/racingcar/domain/Car.kt
+++ b/src/main/kotlin/racingcar/domain/Car.kt
@@ -1,11 +1,13 @@
 package racingcar.domain
 
 class Car(val name: CarName, private val powerGenerator: PowerGenerator) {
-    var position = Position(0)
+    private var _position = Position(0)
+    val position: Position
+        get() = _position
 
     fun move() {
         if (canMove()) {
-            position = position.increase()
+            _position = _position.increase()
         }
     }
 

--- a/src/main/kotlin/racingcar/domain/Car.kt
+++ b/src/main/kotlin/racingcar/domain/Car.kt
@@ -5,7 +5,7 @@ class Car(val name: CarName, private val powerGenerator: PowerGenerator) {
 
     fun move() {
         if (canMove()) {
-            position.increase()
+            position = position.increase()
         }
     }
 

--- a/src/main/kotlin/racingcar/domain/Car.kt
+++ b/src/main/kotlin/racingcar/domain/Car.kt
@@ -1,0 +1,15 @@
+package racingcar.domain
+
+class Car(val name: CarName, private val powerGenerator: PowerGenerator) {
+    var distance = 0
+
+    fun move() {
+        if (canMove()) {
+            distance++
+        }
+    }
+
+    private fun canMove(): Boolean {
+        return powerGenerator.generate() >= 4
+    }
+}

--- a/src/main/kotlin/racingcar/domain/Car.kt
+++ b/src/main/kotlin/racingcar/domain/Car.kt
@@ -1,7 +1,12 @@
 package racingcar.domain
 
 class Car(val name: CarName, private val powerGenerator: PowerGenerator) {
-    private var _position = Position(0)
+    companion object {
+        const val MIN_POWER_TO_MOVE = 4
+        const val INITIAL_POSITION = 0
+    }
+
+    private var _position = Position(INITIAL_POSITION)
     val position: Position
         get() = _position
 
@@ -12,6 +17,6 @@ class Car(val name: CarName, private val powerGenerator: PowerGenerator) {
     }
 
     private fun canMove(): Boolean {
-        return powerGenerator.generate() >= 4
+        return powerGenerator.generate() >= MIN_POWER_TO_MOVE
     }
 }

--- a/src/main/kotlin/racingcar/domain/CarName.kt
+++ b/src/main/kotlin/racingcar/domain/CarName.kt
@@ -5,5 +5,8 @@ class CarName(val name: String) {
         if (name.isEmpty()) {
             throw IllegalArgumentException("Car names must not be empty.")
         }
+        if (name.length > 5) {
+            throw IllegalArgumentException("Car names must not exceed 5 characters.")
+        }
     }
 }

--- a/src/main/kotlin/racingcar/domain/CarName.kt
+++ b/src/main/kotlin/racingcar/domain/CarName.kt
@@ -1,11 +1,11 @@
 package racingcar.domain
 
-class CarName(val name: String) {
+class CarName(val value: String) {
     init {
-        if (name.isEmpty()) {
+        if (value.isEmpty()) {
             throw IllegalArgumentException("Car names must not be empty.")
         }
-        if (name.length > 5) {
+        if (value.length > 5) {
             throw IllegalArgumentException("Car names must not exceed 5 characters.")
         }
     }
@@ -16,10 +16,10 @@ class CarName(val name: String) {
 
         other as CarName
 
-        return name == other.name
+        return value == other.value
     }
 
     override fun hashCode(): Int {
-        return name.hashCode()
+        return value.hashCode()
     }
 }

--- a/src/main/kotlin/racingcar/domain/CarName.kt
+++ b/src/main/kotlin/racingcar/domain/CarName.kt
@@ -1,11 +1,15 @@
 package racingcar.domain
 
 class CarName(val value: String) {
+    companion object {
+        const val MAX_NAME_LENGTH = 5
+    }
+
     init {
         if (value.isEmpty()) {
             throw IllegalArgumentException("Car names must not be empty.")
         }
-        if (value.length > 5) {
+        if (value.length > MAX_NAME_LENGTH) {
             throw IllegalArgumentException("Car names must not exceed 5 characters.")
         }
     }

--- a/src/main/kotlin/racingcar/domain/CarName.kt
+++ b/src/main/kotlin/racingcar/domain/CarName.kt
@@ -1,0 +1,9 @@
+package racingcar.domain
+
+class CarName(val name: String) {
+    init {
+        if (name.isEmpty()) {
+            throw IllegalArgumentException("Car names must not be empty.")
+        }
+    }
+}

--- a/src/main/kotlin/racingcar/domain/CarName.kt
+++ b/src/main/kotlin/racingcar/domain/CarName.kt
@@ -9,4 +9,17 @@ class CarName(val name: String) {
             throw IllegalArgumentException("Car names must not exceed 5 characters.")
         }
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as CarName
+
+        return name == other.name
+    }
+
+    override fun hashCode(): Int {
+        return name.hashCode()
+    }
 }

--- a/src/main/kotlin/racingcar/domain/CarName.kt
+++ b/src/main/kotlin/racingcar/domain/CarName.kt
@@ -1,6 +1,6 @@
 package racingcar.domain
 
-class CarName(val value: String) {
+data class CarName(val value: String) {
     companion object {
         const val MAX_NAME_LENGTH = 5
     }
@@ -12,18 +12,5 @@ class CarName(val value: String) {
         if (value.length > MAX_NAME_LENGTH) {
             throw IllegalArgumentException("Car names must not exceed 5 characters.")
         }
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as CarName
-
-        return value == other.value
-    }
-
-    override fun hashCode(): Int {
-        return value.hashCode()
     }
 }

--- a/src/main/kotlin/racingcar/domain/CarStatus.kt
+++ b/src/main/kotlin/racingcar/domain/CarStatus.kt
@@ -1,0 +1,7 @@
+package racingcar.domain
+
+data class CarStatus(
+    val name: CarName,
+    val position: Position
+) {
+}

--- a/src/main/kotlin/racingcar/domain/Cars.kt
+++ b/src/main/kotlin/racingcar/domain/Cars.kt
@@ -19,8 +19,8 @@ class Cars(private val cars: List<Car>) {
     }
 
     fun winners(): List<Car> {
-        val maxPosition = cars.maxOf { it.position.toInt() }
-        return cars.filter { car -> car.position.toInt() == maxPosition }.toList()
+        val maxPosition = cars.maxOf { it.position.value }
+        return cars.filter { car -> car.position.value == maxPosition }.toList()
     }
 
     fun getCarStatuses(): List<CarStatus> {

--- a/src/main/kotlin/racingcar/domain/Cars.kt
+++ b/src/main/kotlin/racingcar/domain/Cars.kt
@@ -1,7 +1,5 @@
 package racingcar.domain
 
-import kotlin.math.max
-
 class Cars(val cars: List<Car>) {
     init {
         validateUniqueNames()
@@ -21,10 +19,7 @@ class Cars(val cars: List<Car>) {
     }
 
     fun winners(): List<Car> {
-        var maxPosition = 0
-        for (car in cars) {
-            maxPosition = max(maxPosition, car.position.toInt())
-        }
+        val maxPosition = cars.maxOf { it.position.toInt() }
         return cars.filter { car -> car.position.toInt() == maxPosition }.toList()
     }
 }

--- a/src/main/kotlin/racingcar/domain/Cars.kt
+++ b/src/main/kotlin/racingcar/domain/Cars.kt
@@ -6,16 +6,13 @@ class Cars(private val cars: List<Car>) {
     }
 
     private fun validateUniqueNames() {
-        val names = cars.map { it.name }
-        if (names.size != names.toSet().size) {
-            throw IllegalArgumentException("Car names must be unique.")
+        require(cars.map { it.name }.distinct().size == cars.size) {
+            "Car names must be unique."
         }
     }
 
     fun move() {
-        for (car in cars) {
-            car.move()
-        }
+        cars.forEach { it.move() }
     }
 
     fun winners(): List<Car> {

--- a/src/main/kotlin/racingcar/domain/Cars.kt
+++ b/src/main/kotlin/racingcar/domain/Cars.kt
@@ -20,10 +20,10 @@ class Cars(private val cars: List<Car>) {
 
     fun winners(): List<Car> {
         val maxPosition = cars.maxOf { it.position.value }
-        return cars.filter { car -> car.position.value == maxPosition }.toList()
+        return cars.filter { it.position.value == maxPosition }
     }
 
     fun getCarStatuses(): List<CarStatus> {
-        return cars.map { CarStatus(it.name, it.position) }.toList()
+        return cars.map { CarStatus(it.name, it.position) }
     }
 }

--- a/src/main/kotlin/racingcar/domain/Cars.kt
+++ b/src/main/kotlin/racingcar/domain/Cars.kt
@@ -1,0 +1,14 @@
+package racingcar.domain
+
+class Cars(val cars: List<Car>) {
+    init {
+        validateUniqueNames()
+    }
+
+    private fun validateUniqueNames() {
+        val names = cars.map { it.name }
+        if (names.size != names.toSet().size) {
+            throw IllegalArgumentException("Car names must be unique.")
+        }
+    }
+}

--- a/src/main/kotlin/racingcar/domain/Cars.kt
+++ b/src/main/kotlin/racingcar/domain/Cars.kt
@@ -1,5 +1,7 @@
 package racingcar.domain
 
+import kotlin.math.max
+
 class Cars(val cars: List<Car>) {
     init {
         validateUniqueNames()
@@ -16,5 +18,13 @@ class Cars(val cars: List<Car>) {
         for (car in cars) {
             car.move()
         }
+    }
+
+    fun winners(): List<Car> {
+        var maxPosition = 0
+        for (car in cars) {
+            maxPosition = max(maxPosition, car.position)
+        }
+        return cars.filter { car -> car.position == maxPosition }.toList()
     }
 }

--- a/src/main/kotlin/racingcar/domain/Cars.kt
+++ b/src/main/kotlin/racingcar/domain/Cars.kt
@@ -1,6 +1,6 @@
 package racingcar.domain
 
-class Cars(val cars: List<Car>) {
+class Cars(private val cars: List<Car>) {
     init {
         validateUniqueNames()
     }
@@ -21,5 +21,9 @@ class Cars(val cars: List<Car>) {
     fun winners(): List<Car> {
         val maxPosition = cars.maxOf { it.position.toInt() }
         return cars.filter { car -> car.position.toInt() == maxPosition }.toList()
+    }
+
+    fun getCarStatuses(): List<CarStatus> {
+        return cars.map { CarStatus(it.name, it.position) }.toList()
     }
 }

--- a/src/main/kotlin/racingcar/domain/Cars.kt
+++ b/src/main/kotlin/racingcar/domain/Cars.kt
@@ -23,8 +23,8 @@ class Cars(val cars: List<Car>) {
     fun winners(): List<Car> {
         var maxPosition = 0
         for (car in cars) {
-            maxPosition = max(maxPosition, car.position)
+            maxPosition = max(maxPosition, car.position.toInt())
         }
-        return cars.filter { car -> car.position == maxPosition }.toList()
+        return cars.filter { car -> car.position.toInt() == maxPosition }.toList()
     }
 }

--- a/src/main/kotlin/racingcar/domain/Cars.kt
+++ b/src/main/kotlin/racingcar/domain/Cars.kt
@@ -11,4 +11,10 @@ class Cars(val cars: List<Car>) {
             throw IllegalArgumentException("Car names must be unique.")
         }
     }
+
+    fun move() {
+        for (car in cars) {
+            car.move()
+        }
+    }
 }

--- a/src/main/kotlin/racingcar/domain/FixedPowerGenerator.kt
+++ b/src/main/kotlin/racingcar/domain/FixedPowerGenerator.kt
@@ -1,0 +1,7 @@
+package racingcar.domain
+
+class FixedPowerGenerator(private val power: Int) : PowerGenerator {
+    override fun generate(): Int {
+        return power
+    }
+}

--- a/src/main/kotlin/racingcar/domain/Position.kt
+++ b/src/main/kotlin/racingcar/domain/Position.kt
@@ -1,24 +1,11 @@
 package racingcar.domain
 
-class Position(private var value: Int) {
-    fun increase() {
-        value++
+data class Position(private val value: Int) {
+    fun increase(): Position {
+        return Position(value + 1)
     }
 
     fun toInt(): Int {
-        return value
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as Position
-
-        return value == other.value
-    }
-
-    override fun hashCode(): Int {
         return value
     }
 }

--- a/src/main/kotlin/racingcar/domain/Position.kt
+++ b/src/main/kotlin/racingcar/domain/Position.kt
@@ -1,0 +1,24 @@
+package racingcar.domain
+
+class Position(private var value: Int) {
+    fun increase() {
+        value++
+    }
+
+    fun toInt(): Int {
+        return value
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Position
+
+        return value == other.value
+    }
+
+    override fun hashCode(): Int {
+        return value
+    }
+}

--- a/src/main/kotlin/racingcar/domain/Position.kt
+++ b/src/main/kotlin/racingcar/domain/Position.kt
@@ -1,11 +1,7 @@
 package racingcar.domain
 
-data class Position(private val value: Int) {
+data class Position(val value: Int) {
     fun increase(): Position {
         return Position(value + 1)
-    }
-
-    fun toInt(): Int {
-        return value
     }
 }

--- a/src/main/kotlin/racingcar/domain/PowerGenerator.kt
+++ b/src/main/kotlin/racingcar/domain/PowerGenerator.kt
@@ -1,0 +1,5 @@
+package racingcar.domain
+
+interface PowerGenerator {
+    fun generate(): Int
+}

--- a/src/main/kotlin/racingcar/domain/Race.kt
+++ b/src/main/kotlin/racingcar/domain/Race.kt
@@ -1,0 +1,12 @@
+package racingcar.domain
+
+class Race(private val cars: Cars, private val round: Int) {
+    fun start(): RaceResults {
+        val roundResults = ArrayList<RoundResult>()
+        for (i: Int in 1..round) {
+            cars.move()
+            roundResults.add(RoundResult(cars.cars))
+        }
+        return RaceResults(roundResults, cars.winners())
+    }
+}

--- a/src/main/kotlin/racingcar/domain/Race.kt
+++ b/src/main/kotlin/racingcar/domain/Race.kt
@@ -2,10 +2,9 @@ package racingcar.domain
 
 class Race(private val cars: Cars, private val round: Int) {
     fun start(): RaceResults {
-        val roundResults = mutableListOf<RoundResult>()
-        repeat(round) {
+        val roundResults = List(round) {
             cars.move()
-            roundResults.add(RoundResult(cars.getCarStatuses()))
+            RoundResult(cars.getCarStatuses())
         }
         return RaceResults(roundResults, cars.winners())
     }

--- a/src/main/kotlin/racingcar/domain/Race.kt
+++ b/src/main/kotlin/racingcar/domain/Race.kt
@@ -5,7 +5,7 @@ class Race(private val cars: Cars, private val round: Int) {
         val roundResults = ArrayList<RoundResult>()
         for (i: Int in 1..round) {
             cars.move()
-            roundResults.add(RoundResult(cars.cars))
+            roundResults.add(RoundResult(cars.getCarStatuses()))
         }
         return RaceResults(roundResults, cars.winners())
     }

--- a/src/main/kotlin/racingcar/domain/Race.kt
+++ b/src/main/kotlin/racingcar/domain/Race.kt
@@ -2,8 +2,8 @@ package racingcar.domain
 
 class Race(private val cars: Cars, private val round: Int) {
     fun start(): RaceResults {
-        val roundResults = ArrayList<RoundResult>()
-        for (i: Int in 1..round) {
+        val roundResults = mutableListOf<RoundResult>()
+        repeat(round) {
             cars.move()
             roundResults.add(RoundResult(cars.getCarStatuses()))
         }

--- a/src/main/kotlin/racingcar/domain/RaceResults.kt
+++ b/src/main/kotlin/racingcar/domain/RaceResults.kt
@@ -1,0 +1,4 @@
+package racingcar.domain
+
+class RaceResults(val roundResults: List<RoundResult>, val winners: List<Car>) {
+}

--- a/src/main/kotlin/racingcar/domain/RaceResults.kt
+++ b/src/main/kotlin/racingcar/domain/RaceResults.kt
@@ -1,4 +1,7 @@
 package racingcar.domain
 
-class RaceResults(val roundResults: List<RoundResult>, val winners: List<Car>) {
+data class RaceResults(
+    val roundResults: List<RoundResult>,
+    val winners: List<Car>
+) {
 }

--- a/src/main/kotlin/racingcar/domain/RandomPowerGenerator.kt
+++ b/src/main/kotlin/racingcar/domain/RandomPowerGenerator.kt
@@ -3,7 +3,12 @@ package racingcar.domain
 import camp.nextstep.edu.missionutils.Randoms
 
 class RandomPowerGenerator : PowerGenerator {
+    companion object {
+        const val MIN_POWER = 0
+        const val MAX_POWER = 9
+    }
+
     override fun generate(): Int {
-        return Randoms.pickNumberInRange(0, 9)
+        return Randoms.pickNumberInRange(MIN_POWER, MAX_POWER)
     }
 }

--- a/src/main/kotlin/racingcar/domain/RandomPowerGenerator.kt
+++ b/src/main/kotlin/racingcar/domain/RandomPowerGenerator.kt
@@ -1,0 +1,9 @@
+package racingcar.domain
+
+import camp.nextstep.edu.missionutils.Randoms
+
+class RandomPowerGenerator : PowerGenerator {
+    override fun generate(): Int {
+        return Randoms.pickNumberInRange(0, 9)
+    }
+}

--- a/src/main/kotlin/racingcar/domain/RoundResult.kt
+++ b/src/main/kotlin/racingcar/domain/RoundResult.kt
@@ -1,6 +1,6 @@
 package racingcar.domain
 
 class RoundResult(cars: List<Car>) {
-    val results: Map<String, Int> =
-        cars.associate { it.name.name to it.position }
+    val results: Map<CarName, Position> =
+        cars.associate { it.name to it.position }
 }

--- a/src/main/kotlin/racingcar/domain/RoundResult.kt
+++ b/src/main/kotlin/racingcar/domain/RoundResult.kt
@@ -1,6 +1,4 @@
 package racingcar.domain
 
-class RoundResult(cars: List<Car>) {
-    val results: Map<CarName, Position> =
-        cars.associate { it.name to it.position }
+data class RoundResult(val carStatuses: List<CarStatus>) {
 }

--- a/src/main/kotlin/racingcar/domain/RoundResult.kt
+++ b/src/main/kotlin/racingcar/domain/RoundResult.kt
@@ -1,0 +1,6 @@
+package racingcar.domain
+
+class RoundResult(cars: List<Car>) {
+    val results: Map<String, Int> =
+        cars.associate { it.name.name to it.position }
+}

--- a/src/main/kotlin/racingcar/view/InputParser.kt
+++ b/src/main/kotlin/racingcar/view/InputParser.kt
@@ -1,0 +1,14 @@
+package racingcar.view
+
+class InputParser {
+    fun parseCarNames(input: String): List<String> {
+        validateEmptyInput(input)
+        return input.split(",").map { it.trim() }
+    }
+
+    private fun validateEmptyInput(input: String) {
+        if (input.isBlank()) {
+            throw IllegalArgumentException("Input must not be empty.")
+        }
+    }
+}

--- a/src/main/kotlin/racingcar/view/InputParser.kt
+++ b/src/main/kotlin/racingcar/view/InputParser.kt
@@ -6,6 +6,29 @@ class InputParser {
         return input.split(",").map { it.trim() }
     }
 
+    fun parseNumberOfRounds(input: String): Int {
+        validateEmptyInput(input)
+        val trimmed = input.trim()
+        validateMultipleInputs(trimmed)
+        val numberOfRounds = trimmed.toIntOrNull()
+            ?: throw IllegalArgumentException("The Round number input is not possible, not numbers.")
+        validateGreaterThanZero(numberOfRounds)
+        return numberOfRounds
+    }
+
+    private fun validateGreaterThanZero(numberOfRounds: Int) {
+        if (numberOfRounds <= 0) {
+            throw IllegalArgumentException("The round number input should be larger than zero.")
+        }
+    }
+
+    private fun validateMultipleInputs(trimmed: String) {
+        val tokens = trimmed.split(Regex("\\s+"))
+        if (tokens.size > 1) {
+            throw IllegalArgumentException("Only one number of rounds can be entered.")
+        }
+    }
+
     private fun validateEmptyInput(input: String) {
         if (input.isBlank()) {
             throw IllegalArgumentException("Input must not be empty.")

--- a/src/main/kotlin/racingcar/view/InputView.kt
+++ b/src/main/kotlin/racingcar/view/InputView.kt
@@ -9,4 +9,9 @@ class InputView {
         val input = Console.readLine()
         return parser.parseCarNames(input)
     }
+
+    fun readNumberOfRounds(): Int {
+        val input = Console.readLine()
+        return parser.parseNumberOfRounds(input)
+    }
 }

--- a/src/main/kotlin/racingcar/view/InputView.kt
+++ b/src/main/kotlin/racingcar/view/InputView.kt
@@ -6,11 +6,13 @@ class InputView {
     private val parser = InputParser()
 
     fun readCarNames(): List<String> {
+        println("Enter the names of the cars (comma-separated):")
         val input = Console.readLine()
         return parser.parseCarNames(input)
     }
 
     fun readNumberOfRounds(): Int {
+        println("How many rounds will be played?")
         val input = Console.readLine()
         return parser.parseNumberOfRounds(input)
     }

--- a/src/main/kotlin/racingcar/view/InputView.kt
+++ b/src/main/kotlin/racingcar/view/InputView.kt
@@ -1,0 +1,12 @@
+package racingcar.view
+
+import camp.nextstep.edu.missionutils.Console
+
+class InputView {
+    private val parser = InputParser()
+
+    fun readCarNames(): List<String> {
+        val input = Console.readLine()
+        return parser.parseCarNames(input)
+    }
+}

--- a/src/main/kotlin/racingcar/view/OutputView.kt
+++ b/src/main/kotlin/racingcar/view/OutputView.kt
@@ -13,9 +13,9 @@ class OutputView {
     }
 
     private fun printRoundResult(roundResult: RoundResult) {
-        for (entry in roundResult.results.entries) {
-            print(entry.key.name + " : ")
-            println("-".repeat(entry.value.toInt()))
+        for (carStatus in roundResult.carStatuses) {
+            print(carStatus.name.name + " : ")
+            println("-".repeat(carStatus.position.toInt()))
         }
         println()
     }

--- a/src/main/kotlin/racingcar/view/OutputView.kt
+++ b/src/main/kotlin/racingcar/view/OutputView.kt
@@ -14,14 +14,14 @@ class OutputView {
 
     private fun printRoundResult(roundResult: RoundResult) {
         for (carStatus in roundResult.carStatuses) {
-            print(carStatus.name.name + " : ")
-            println("-".repeat(carStatus.position.toInt()))
+            print(carStatus.name.value + " : ")
+            println("-".repeat(carStatus.position.value))
         }
         println()
     }
 
     private fun printWinners(raceResults: RaceResults) {
-        val winners = raceResults.winners.joinToString(", ") { it.name.name }
+        val winners = raceResults.winners.joinToString(", ") { it.name.value }
         println("Winners : $winners")
     }
 }

--- a/src/main/kotlin/racingcar/view/OutputView.kt
+++ b/src/main/kotlin/racingcar/view/OutputView.kt
@@ -1,0 +1,27 @@
+package racingcar.view
+
+import racingcar.domain.RaceResults
+import racingcar.domain.RoundResult
+
+class OutputView {
+    fun printRaceResults(raceResults: RaceResults) {
+        println("\nRace Results")
+        for (roundResult in raceResults.roundResults) {
+            printRoundResult(roundResult)
+        }
+        printWinners(raceResults)
+    }
+
+    private fun printRoundResult(roundResult: RoundResult) {
+        for (entry in roundResult.results.entries) {
+            print(entry.key + " : ")
+            println("-".repeat(entry.value))
+        }
+        println()
+    }
+
+    private fun printWinners(raceResults: RaceResults) {
+        val winners = raceResults.winners.joinToString(", ") { it.name.name }
+        println("Winners : $winners")
+    }
+}

--- a/src/main/kotlin/racingcar/view/OutputView.kt
+++ b/src/main/kotlin/racingcar/view/OutputView.kt
@@ -14,8 +14,8 @@ class OutputView {
 
     private fun printRoundResult(roundResult: RoundResult) {
         for (entry in roundResult.results.entries) {
-            print(entry.key + " : ")
-            println("-".repeat(entry.value))
+            print(entry.key.name + " : ")
+            println("-".repeat(entry.value.toInt()))
         }
         println()
     }

--- a/src/test/kotlin/racingcar/domain/CarNameTest.kt
+++ b/src/test/kotlin/racingcar/domain/CarNameTest.kt
@@ -1,0 +1,16 @@
+package racingcar.domain
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class CarNameTest {
+
+    @Test
+    fun `Car names must not be empty`() {
+        val exception = assertThrows<IllegalArgumentException> {
+            CarName("")
+        }
+        assertEquals("Car names must not be empty.", exception.message)
+    }
+}

--- a/src/test/kotlin/racingcar/domain/CarNameTest.kt
+++ b/src/test/kotlin/racingcar/domain/CarNameTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
 class CarNameTest {
-
     @Test
     fun `Car names must not be empty`() {
         val exception = assertThrows<IllegalArgumentException> {

--- a/src/test/kotlin/racingcar/domain/CarNameTest.kt
+++ b/src/test/kotlin/racingcar/domain/CarNameTest.kt
@@ -3,6 +3,8 @@ package racingcar.domain
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 class CarNameTest {
 
@@ -12,5 +14,14 @@ class CarNameTest {
             CarName("")
         }
         assertEquals("Car names must not be empty.", exception.message)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["123456", "more than five letters"])
+    fun `Car names must not exceed 5 characters`(name: String) {
+        val exception = assertThrows<IllegalArgumentException> {
+            CarName(name)
+        }
+        assertEquals("Car names must not exceed 5 characters.", exception.message)
     }
 }

--- a/src/test/kotlin/racingcar/domain/CarTest.kt
+++ b/src/test/kotlin/racingcar/domain/CarTest.kt
@@ -5,7 +5,6 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
 class CarTest {
-
     private val carName: CarName = CarName("pobi")
 
     @ParameterizedTest

--- a/src/test/kotlin/racingcar/domain/CarTest.kt
+++ b/src/test/kotlin/racingcar/domain/CarTest.kt
@@ -13,7 +13,7 @@ class CarTest {
     fun `car moves if power is 4 or greater`(power: Int) {
         val car = Car(carName, FixedPowerGenerator(power))
         car.move()
-        assertEquals(1, car.distance)
+        assertEquals(1, car.position)
     }
 
     @ParameterizedTest
@@ -21,6 +21,6 @@ class CarTest {
     fun `car cannot moves if power is under 4`(power: Int) {
         val car = Car(carName, FixedPowerGenerator(power))
         car.move()
-        assertEquals(0, car.distance)
+        assertEquals(0, car.position)
     }
 }

--- a/src/test/kotlin/racingcar/domain/CarTest.kt
+++ b/src/test/kotlin/racingcar/domain/CarTest.kt
@@ -13,7 +13,7 @@ class CarTest {
     fun `car moves if power is 4 or greater`(power: Int) {
         val car = Car(carName, FixedPowerGenerator(power))
         car.move()
-        assertEquals(1, car.position)
+        assertEquals(Position(1), car.position)
     }
 
     @ParameterizedTest
@@ -21,6 +21,6 @@ class CarTest {
     fun `car cannot moves if power is under 4`(power: Int) {
         val car = Car(carName, FixedPowerGenerator(power))
         car.move()
-        assertEquals(0, car.position)
+        assertEquals(Position(0), car.position)
     }
 }

--- a/src/test/kotlin/racingcar/domain/CarTest.kt
+++ b/src/test/kotlin/racingcar/domain/CarTest.kt
@@ -1,0 +1,26 @@
+package racingcar.domain
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class CarTest {
+
+    private val carName: CarName = CarName("pobi")
+
+    @ParameterizedTest
+    @ValueSource(ints = [4, 5, 123])
+    fun `car moves if power is 4 or greater`(power: Int) {
+        val car = Car(carName, FixedPowerGenerator(power))
+        car.move()
+        assertEquals(1, car.distance)
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [1, 2, 3])
+    fun `car cannot moves if power is under 4`(power: Int) {
+        val car = Car(carName, FixedPowerGenerator(power))
+        car.move()
+        assertEquals(0, car.distance)
+    }
+}

--- a/src/test/kotlin/racingcar/domain/CarsTest.kt
+++ b/src/test/kotlin/racingcar/domain/CarsTest.kt
@@ -8,50 +8,43 @@ class CarsTest {
 
     @Test
     fun `Car names must be unique`() {
-        val carName1 = CarName("pobi")
-        val car1 = Car(carName1, RandomPowerGenerator())
-        val carName2 = CarName("pobi")
-        val car2 = Car(carName2, RandomPowerGenerator())
+        val carName = CarName("pobi")
+        val pobiFirst = Car(carName, RandomPowerGenerator())
+        val pobiSecond = Car(carName, RandomPowerGenerator())
 
         val exception = assertThrows<IllegalArgumentException> {
-            Cars(listOf(car1, car2))
+            Cars(listOf(pobiFirst, pobiSecond))
         }
         assertEquals("Car names must be unique.", exception.message)
     }
 
     @Test
     fun `every car attempts to move`() {
-        val carName1 = CarName("pobi")
-        val carPobi = Car(carName1, FixedPowerGenerator(4))
-        val carName2 = CarName("tebah")
-        val carTebah = Car(carName2, FixedPowerGenerator(3))
-        val carName3 = CarName("anna")
-        val carAnna = Car(carName3, FixedPowerGenerator(5))
-        val cars = Cars(listOf(carPobi, carTebah, carAnna))
+        val pobi = Car(CarName("pobi"), FixedPowerGenerator(4))
+        val tebah = Car(CarName("tebah"), FixedPowerGenerator(3))
+        val anna = Car(CarName("anna"), FixedPowerGenerator(5))
+        val cars = Cars(listOf(pobi, tebah, anna))
 
         cars.move()
 
-        assertEquals(1, carPobi.position)
-        assertEquals(0, carTebah.position)
-        assertEquals(1, carAnna.position)
+        assertEquals(1, pobi.position)
+        assertEquals(0, tebah.position)
+        assertEquals(1, anna.position)
     }
 
     @Test
     fun `returns all cars that moved the farthest as winners`() {
-        val carName1 = CarName("pobi")
-        val carPobi = Car(carName1, FixedPowerGenerator(4))
-        val carName2 = CarName("tebah")
-        val carTebah = Car(carName2, FixedPowerGenerator(3))
-        val carName3 = CarName("anna")
-        val carAnna = Car(carName3, FixedPowerGenerator(5))
-        val cars = Cars(listOf(carPobi, carTebah, carAnna))
+        val pobi = Car(CarName("pobi"), FixedPowerGenerator(4))
+        val tebah = Car(CarName("tebah"), FixedPowerGenerator(3))
+        val anna = Car(CarName("anna"), FixedPowerGenerator(5))
+        val cars = Cars(listOf(pobi, tebah, anna))
 
         cars.move()
 
         val winners = cars.winners()
         assertEquals(2, winners.size)
-        assertTrue(carPobi in winners)
-        assertTrue(carAnna in winners)
-        assertFalse(carTebah in winners)
+        assertTrue(pobi in winners)
+        assertTrue(anna in winners)
+        assertFalse(tebah in winners)
     }
 }

--- a/src/test/kotlin/racingcar/domain/CarsTest.kt
+++ b/src/test/kotlin/racingcar/domain/CarsTest.kt
@@ -1,6 +1,6 @@
 package racingcar.domain
 
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
@@ -34,5 +34,24 @@ class CarsTest {
         assertEquals(1, carPobi.position)
         assertEquals(0, carTebah.position)
         assertEquals(1, carAnna.position)
+    }
+
+    @Test
+    fun `returns all cars that moved the farthest as winners`() {
+        val carName1 = CarName("pobi")
+        val carPobi = Car(carName1, FixedPowerGenerator(4))
+        val carName2 = CarName("tebah")
+        val carTebah = Car(carName2, FixedPowerGenerator(3))
+        val carName3 = CarName("anna")
+        val carAnna = Car(carName3, FixedPowerGenerator(5))
+        val cars = Cars(listOf(carPobi, carTebah, carAnna))
+
+        cars.move()
+
+        val winners = cars.winners()
+        assertEquals(2, winners.size)
+        assertTrue(carPobi in winners)
+        assertTrue(carAnna in winners)
+        assertFalse(carTebah in winners)
     }
 }

--- a/src/test/kotlin/racingcar/domain/CarsTest.kt
+++ b/src/test/kotlin/racingcar/domain/CarsTest.kt
@@ -18,4 +18,21 @@ class CarsTest {
         }
         assertEquals("Car names must be unique.", exception.message)
     }
+
+    @Test
+    fun `every car attempts to move`() {
+        val carName1 = CarName("pobi")
+        val carPobi = Car(carName1, FixedPowerGenerator(4))
+        val carName2 = CarName("tebah")
+        val carTebah = Car(carName2, FixedPowerGenerator(3))
+        val carName3 = CarName("anna")
+        val carAnna = Car(carName3, FixedPowerGenerator(5))
+        val cars = Cars(listOf(carPobi, carTebah, carAnna))
+
+        cars.move()
+
+        assertEquals(1, carPobi.position)
+        assertEquals(0, carTebah.position)
+        assertEquals(1, carAnna.position)
+    }
 }

--- a/src/test/kotlin/racingcar/domain/CarsTest.kt
+++ b/src/test/kotlin/racingcar/domain/CarsTest.kt
@@ -1,0 +1,21 @@
+package racingcar.domain
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class CarsTest {
+
+    @Test
+    fun `Car names must be unique`() {
+        val carName1 = CarName("pobi")
+        val car1 = Car(carName1, RandomPowerGenerator())
+        val carName2 = CarName("pobi")
+        val car2 = Car(carName2, RandomPowerGenerator())
+
+        val exception = assertThrows<IllegalArgumentException> {
+            Cars(listOf(car1, car2))
+        }
+        assertEquals("Car names must be unique.", exception.message)
+    }
+}

--- a/src/test/kotlin/racingcar/domain/CarsTest.kt
+++ b/src/test/kotlin/racingcar/domain/CarsTest.kt
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class CarsTest {
-
     @Test
     fun `Car names must be unique`() {
         val carName = CarName("pobi")

--- a/src/test/kotlin/racingcar/domain/CarsTest.kt
+++ b/src/test/kotlin/racingcar/domain/CarsTest.kt
@@ -27,9 +27,9 @@ class CarsTest {
 
         cars.move()
 
-        assertEquals(1, pobi.position)
-        assertEquals(0, tebah.position)
-        assertEquals(1, anna.position)
+        assertEquals(Position(1), pobi.position)
+        assertEquals(Position(0), tebah.position)
+        assertEquals(Position(1), anna.position)
     }
 
     @Test

--- a/src/test/kotlin/racingcar/domain/PositionTest.kt
+++ b/src/test/kotlin/racingcar/domain/PositionTest.kt
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class PositionTest {
-
     @Test
     fun `increase car position by 1`() {
         val position = Position(0)

--- a/src/test/kotlin/racingcar/domain/PositionTest.kt
+++ b/src/test/kotlin/racingcar/domain/PositionTest.kt
@@ -9,8 +9,8 @@ class PositionTest {
     fun `increase car position by 1`() {
         val position = Position(0)
 
-        position.increase()
+        val increasedPosition = position.increase()
 
-        assertEquals(1, position.toInt())
+        assertEquals(Position(1), increasedPosition)
     }
 }

--- a/src/test/kotlin/racingcar/domain/PositionTest.kt
+++ b/src/test/kotlin/racingcar/domain/PositionTest.kt
@@ -1,0 +1,16 @@
+package racingcar.domain
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class PositionTest {
+
+    @Test
+    fun `increase car position by 1`() {
+        val position = Position(0)
+
+        position.increase()
+
+        assertEquals(1, position.toInt())
+    }
+}

--- a/src/test/kotlin/racingcar/domain/RaceTest.kt
+++ b/src/test/kotlin/racingcar/domain/RaceTest.kt
@@ -1,0 +1,32 @@
+package racingcar.domain
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class RaceTest {
+
+    @Test
+    fun `proceed for a given number of rounds`() {
+        val winner = Car(CarName("pobi"), FixedPowerGenerator(4))
+        val loser = Car(CarName("tebah"), FixedPowerGenerator(3))
+        val cars = Cars(listOf(winner, loser))
+        val race = Race(cars, 5)
+
+        val result = race.start()
+
+        assertEquals(5, result.roundResults.size)
+    }
+
+    @Test
+    fun `When the game ends, a winner is determined`() {
+        val winner = Car(CarName("pobi"), FixedPowerGenerator(4))
+        val loser = Car(CarName("tebah"), FixedPowerGenerator(3))
+        val cars = Cars(listOf(winner, loser))
+        val race = Race(cars, 5)
+
+        val result = race.start()
+
+        assertTrue(winner in result.winners)
+        assertFalse(loser in result.winners)
+    }
+}

--- a/src/test/kotlin/racingcar/domain/RaceTest.kt
+++ b/src/test/kotlin/racingcar/domain/RaceTest.kt
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
 class RaceTest {
-
     @Test
     fun `proceed for a given number of rounds`() {
         val winner = Car(CarName("pobi"), FixedPowerGenerator(4))

--- a/src/test/kotlin/racingcar/view/InputParserTest.kt
+++ b/src/test/kotlin/racingcar/view/InputParserTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
 
 class InputParserTest {
@@ -21,9 +22,60 @@ class InputParserTest {
 
     @ParameterizedTest
     @ValueSource(strings = ["  ", ""])
-    fun `Throws an exception if input is empty`(input: String) {
-        assertThrows<IllegalArgumentException> {
+    fun `Throws an exception if car names input is empty`(input: String) {
+        val exception = assertThrows<IllegalArgumentException> {
             parser.parseCarNames(input)
         }
+        assertEquals("Input must not be empty.", exception.message)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "1, 1",
+        "'5 ', 5",
+        "'    6', 6",
+        "'  10  ', 10"
+    )
+    fun `Parse the number of rounds`(input: String, expected: Int) {
+        val result = parser.parseNumberOfRounds(input)
+        assertEquals(expected, result)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["  ", ""])
+    fun `Throws an exception if number of rounds input is empty`(input: String) {
+        val exception = assertThrows<IllegalArgumentException> {
+            parser.parseNumberOfRounds(input)
+        }
+        assertEquals("Input must not be empty.", exception.message)
+    }
+
+    @Test
+    fun `Throws an exception if number of rounds input is not a number`() {
+        val input = "one"
+
+        val exception = assertThrows<IllegalArgumentException> {
+            parser.parseNumberOfRounds(input)
+        }
+        assertEquals("The Round number input is not possible, not numbers.", exception.message)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["-1", "0"])
+    fun `Throws an exception if number of rounds input is less than zero`(input: String) {
+        val exception = assertThrows<IllegalArgumentException> {
+            parser.parseNumberOfRounds(input)
+        }
+        assertEquals("The round number input should be larger than zero.", exception.message)
+    }
+
+    @Test
+    fun `Throws an exception if there are multiple inputs`() {
+        val input = "1 6"
+
+        val exception = assertThrows<IllegalArgumentException> {
+            parser.parseNumberOfRounds(input)
+        }
+        assertEquals("Only one number of rounds can be entered.", exception.message)
     }
 }

--- a/src/test/kotlin/racingcar/view/InputParserTest.kt
+++ b/src/test/kotlin/racingcar/view/InputParserTest.kt
@@ -8,7 +8,6 @@ import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
 
 class InputParserTest {
-
     private val parser = InputParser()
 
     @Test

--- a/src/test/kotlin/racingcar/view/InputParserTest.kt
+++ b/src/test/kotlin/racingcar/view/InputParserTest.kt
@@ -1,0 +1,29 @@
+package racingcar.view
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class InputParserTest {
+
+    private val parser = InputParser()
+
+    @Test
+    fun `Parse the car name input separated by commas`() {
+        val input = "pobi, anna, tebah"
+
+        val carNames = parser.parseCarNames(input)
+
+        assertEquals(listOf("pobi", "anna", "tebah"), carNames)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["  ", ""])
+    fun `Throws an exception if input is empty`(input: String) {
+        assertThrows<IllegalArgumentException> {
+            parser.parseCarNames(input)
+        }
+    }
+}


### PR DESCRIPTION
# kotlin-racingcar-precourse

## Feature Specification

### Domain Features

| Feature                                                                                                | Status |
|--------------------------------------------------------------------------------------------------------|--------|
| Each car must have a name, and names must not exceed 5 characters.                                     | ✅      |
| Car names must not be empty.                                                                           | ✅      |
| Car names must be unique.                                                                              | ✅      |
| A car can move only when the power condition is satisfied.                                             | ✅      |
| &nbsp;&nbsp;&nbsp;&nbsp;– The power is a random number between 0 and 9.                                | ✅      |
| &nbsp;&nbsp;&nbsp;&nbsp;– The car moves forward if the power is 4 or greater.                          | ✅      |
| The game must proceed for a given number of rounds.                                                    | ✅      |
| &nbsp;&nbsp;&nbsp;&nbsp;– In each round, every car attempts to move once.                              | ✅      |
| &nbsp;&nbsp;&nbsp;&nbsp;– The result of each round (car positions) must be recorded.                   | ✅      |
| After all rounds, determine the winner(s).                                                             | ✅      |
| &nbsp;&nbsp;&nbsp;&nbsp;– The winner is the car(s) that has moved the farthest.                        | ✅      |
| &nbsp;&nbsp;&nbsp;&nbsp;– If there are multiple cars with the same farthest position, all are winners. | ✅      |

---

### Input/Output Features

| Feature                                                                                          | Status |
|--------------------------------------------------------------------------------------------------|--------|
| If the user inputs invalid data, the program must throw an `IllegalArgumentException`.           | ✅      |
| &nbsp;&nbsp;&nbsp;&nbsp;– Input data cannot be empty.                                            | ✅      |
| &nbsp;&nbsp;&nbsp;&nbsp;– Only one number of rounds can be entered.                              | ✅      |
| &nbsp;&nbsp;&nbsp;&nbsp;– The round number input should be larger than zero.                     | ✅      |
| &nbsp;&nbsp;&nbsp;&nbsp;– The round number input must be numeric.                                | ✅      |
| Car names must be entered as a comma-separated list.                                             | ✅      |
| When printing the progress of each car, the car's name must be displayed alongside its movement. | ✅      |
| After the race is complete, the winners must be displayed.                                       | ✅      |
| If there are multiple winners, their names must be separated by commas.                          | ✅      |

### Commit Scopes Convention

To make it easier to trace commits and match them with the feature specification, the following scope conventions are
used in commit messages:

| Scope    | Description                                                                                                |
|----------|------------------------------------------------------------------------------------------------------------|
| `domain` | Changes related to core business logic and domain rules (e.g. race rules, car behavior, round processing). |
| `input`  | Parsing and validation of user inputs (e.g. car names, round count).                                       |
| `output` | Printing the game progress and results (e.g. car positions, winners).                                      |
| `readme` | Updates to documentation files such as `README.md` or spec clarifications.                                 |

#### Example:

```bash
feat(domain): add race progression logic

feat(input): add reading car names features

docs(readme): add input constraints
```
